### PR TITLE
Upgrade to Laravel 8

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -13,7 +13,7 @@
     "authors": [
         {
             "name": "Martin Bock",
-            "email": "mail@mnbo.de",
+            "email": "opensource@martin-bock.com",
             "homepage": "https://martin-bock.com",
             "role": "Developer"
         }
@@ -29,12 +29,12 @@
         }
     },
     "require": {
-        "php": "^7.2",
-        "laravel/framework": "~5.8.0|^6.0|^7.0"
+        "php": "^7.2.5|^8.0",
+        "laravel/framework": "^7.0|^8.0"
     },
     "require-dev": {
-        "orchestra/testbench": "3.8.*|4.*|5.*",
-        "phpunit/phpunit": "^8.4|^9.0"
+        "orchestra/testbench": "5.*|6.*",
+        "phpunit/phpunit": "^8.5|^9.0"
     },
     "autoload": {
         "psr-4": {


### PR DESCRIPTION
With this pull request, support for Laravel 8 and PHP 8 is added.

Support for Laravel 5.8 and 6 is removed.