### PR TITLE
Feature: numbers prepending passphrases

### DIFF
--- a/README.md
+++ b/README.md
@@ -50,6 +50,7 @@ your Laravel config directory once you install this package. Currently, the foll
 'number_of_words'       => 6,
 'separator'             => '-',
 'capitalize'            => false,
+'add_number'            => false,
 'wordlist'              => 'english',
 'custom_wordlist_path'  => null,
 'number_of_dice'        => 5,

--- a/config/diceware.php
+++ b/config/diceware.php
@@ -43,6 +43,19 @@ return [
 
     /*
     |--------------------------------------------------------------------------
+    | Add a Number
+    |--------------------------------------------------------------------------
+    |
+    | If you want to include a number in every generated password, set this
+    | option to `true`. The number will be prepended to the passphrase.
+    | Example: '93neglector-silly-papaya-mankind-feel-portly'
+    |
+    */
+
+    'add_number' => false,
+
+    /*
+    |--------------------------------------------------------------------------
     | Wordlist
     |--------------------------------------------------------------------------
     |
@@ -81,5 +94,4 @@ return [
     */
 
     'number_of_dice' => 5,
-
 ];

--- a/config/diceware.php
+++ b/config/diceware.php
@@ -48,7 +48,7 @@ return [
     |
     | If you want to include a number in every generated password, set this
     | option to `true`. The number will be prepended to the passphrase.
-    | Example: '93neglector-silly-papaya-mankind-feel-portly'
+    | Example: '93-neglector-silly-papaya-mankind-feel-portly'
     |
     */
 

--- a/src/DicewareServiceProvider.php
+++ b/src/DicewareServiceProvider.php
@@ -55,7 +55,6 @@ class DicewareServiceProvider extends ServiceProvider
      * Throw an exception on configuration errors.
      *
      * @param array $config
-     *
      * @throws InvalidConfigurationException
      */
     public function protectFromInvalidConfiguration(array $config)

--- a/src/WordGenerator.php
+++ b/src/WordGenerator.php
@@ -47,6 +47,7 @@ class WordGenerator
     public function generateDicedNumber(): string
     {
         $result = '';
+        
         for ($i = 0; $i < $this->getNumberOfDice(); $i++) {
             $result .= strval($this->rollDice());
         }

--- a/src/WordGenerator.php
+++ b/src/WordGenerator.php
@@ -47,7 +47,7 @@ class WordGenerator
     public function generateDicedNumber(): string
     {
         $result = '';
-        
+
         for ($i = 0; $i < $this->getNumberOfDice(); $i++) {
             $result .= strval($this->rollDice());
         }

--- a/src/WordGenerator.php
+++ b/src/WordGenerator.php
@@ -7,15 +7,15 @@ use function fclose;
 use function feof;
 use function fgets;
 use function fopen;
-use Illuminate\Support\Facades\File;
 use function implode;
-use Martbock\Diceware\Exceptions\InvalidConfigurationException;
-use Martbock\Diceware\Exceptions\WordlistInvalidException;
 use function preg_match;
 use function random_int;
 use function strpos;
 use function strval;
 use function ucfirst;
+use Illuminate\Support\Facades\File;
+use Martbock\Diceware\Exceptions\InvalidConfigurationException;
+use Martbock\Diceware\Exceptions\WordlistInvalidException;
 
 class WordGenerator
 {
@@ -30,9 +30,8 @@ class WordGenerator
     /**
      * Generate a cryptographically secure integer between 1 and 6.
      *
-     * @throws \Exception Thrown if there is not enough entropy.
-     *
      * @return int
+     * @throws \Exception Thrown if there is not enough entropy.
      */
     public function rollDice(): int
     {
@@ -42,9 +41,8 @@ class WordGenerator
     /**
      * Generate a number that can be looked up in a diceware wordlist.
      *
-     * @throws \Exception Thrown if there is not enough entropy.
-     *
      * @return string
+     * @throws \Exception Thrown if there is not enough entropy.
      */
     public function generateDicedNumber(): string
     {
@@ -73,17 +71,15 @@ class WordGenerator
      */
     public function getWordlistPath(): string
     {
-        return $this->config['custom_wordlist_path'] ?: __DIR__.'/../wordlists/'.$this->config['wordlist'].'.txt';
+        return $this->config['custom_wordlist_path'] ?: __DIR__ . '/../wordlists/' . $this->config['wordlist'] . '.txt';
     }
 
     /**
      * Parse the word from the provided wordlist line.
      *
      * @param string $line
-     *
-     * @throws WordlistInvalidException
-     *
      * @return mixed
+     * @throws WordlistInvalidException
      */
     public function parseWord(string $line): string
     {
@@ -100,11 +96,9 @@ class WordGenerator
      * Get the diced word from the wordlist.
      *
      * @param string $dicedNumber
-     *
-     * @throws WordlistInvalidException
-     * @throws InvalidConfigurationException
-     *
      * @return string
+     * @throws InvalidConfigurationException
+     * @throws WordlistInvalidException
      */
     public function getWord(string $dicedNumber): string
     {
@@ -135,10 +129,8 @@ class WordGenerator
      * Get words from the diceware wordlist.
      *
      * @param int $numberOfWords
-     *
-     * @throws \Exception Thrown if there is not enough entropy.
-     *
      * @return array
+     * @throws \Exception Thrown if there is not enough entropy.
      */
     public function generateWords(int $numberOfWords): array
     {
@@ -157,12 +149,11 @@ class WordGenerator
     /**
      * Generate a diceware passphrase.
      *
-     * @param int    $numberOfWords
-     * @param string $separator
-     *
-     * @throws \Exception Thrown if there is not enough entropy.
+     * @param int|null $numberOfWords
+     * @param string|null $separator
      *
      * @return string
+     * @throws \Exception Thrown if there is not enough entropy.
      */
     public function generatePassphrase(?int $numberOfWords = null, ?string $separator = null): string
     {
@@ -171,13 +162,19 @@ class WordGenerator
 
         $words = $this->generateWords($numberOfWords);
 
-        return implode($separator, $words);
+        $phrase = implode($separator, $words);
+
+        if ($this->config['add_number']) {
+            return random_int(1, 999) . $this->config['separator'] . $phrase;
+        }
+
+        return $phrase;
     }
 
     /**
      * Set a config variable for this instance.
      *
-     * @param string                     $key   Config key
+     * @param string $key Config key
      * @param string|int|float|bool|null $value Value for config key
      */
     public function setConfig(string $key, $value): void

--- a/tests/Unit/WordGeneratorTest.php
+++ b/tests/Unit/WordGeneratorTest.php
@@ -106,6 +106,9 @@ class WordGeneratorTest extends TestCase
         $result = $this->wordGenerator->generatePassphrase();
         $arr = explode($this->config['separator'], $result);
         $this->assertIsNumeric($arr[0]);
+        for ($i = 1; $i < $this->config['number_of_words']; $i++) {
+            $this->assertIsNotNumeric($arr[$i]);
+        }
     }
 
     /** @test
@@ -116,6 +119,8 @@ class WordGeneratorTest extends TestCase
         $this->wordGenerator->setConfig('add_number', false);
         $result = $this->wordGenerator->generatePassphrase();
         $arr = explode($this->config['separator'], $result);
-        $this->assertIsNotNumeric($arr[0]);
+        for ($i = 0; $i < $this->config['number_of_words']; $i++) {
+            $this->assertIsNotNumeric($arr[$i]);
+        }
     }
 }

--- a/tests/Unit/WordGeneratorTest.php
+++ b/tests/Unit/WordGeneratorTest.php
@@ -23,6 +23,7 @@ class WordGeneratorTest extends TestCase
             'number_of_words'      => 6,
             'separator'            => '-',
             'capitalize'           => false,
+            'add_number'           => false,
             'wordlist'             => 'eff',
             'custom_wordlist_path' => null,
             'number_of_dice'       => 5,
@@ -36,7 +37,7 @@ class WordGeneratorTest extends TestCase
     public function should_generate_diceware_number()
     {
         $number = $this->wordGenerator->generateDicedNumber();
-        $this->assertTrue(is_int((int) $number));
+        $this->assertTrue(is_int((int)$number));
         $this->assertEquals($this->config['number_of_dice'], strlen($number));
     }
 
@@ -75,12 +76,46 @@ class WordGeneratorTest extends TestCase
     /** @test
      * @throws \Exception
      */
-    public function should_capitalize()
+    public function should_capitalize_when_active()
     {
         $this->wordGenerator->setConfig('capitalize', true);
         $words = $this->wordGenerator->generateWords(1);
         foreach ($words as $word) {
             $this->assertEquals(ucfirst($word), $word);
         }
+    }
+
+    /** @test
+     * @throws \Exception
+     */
+    public function should_not_capitalize_when_inactive()
+    {
+        $this->wordGenerator->setConfig('capitalize', false);
+        $words = $this->wordGenerator->generateWords(1);
+        foreach ($words as $word) {
+            $this->assertEquals(strtolower($word), $word);
+        }
+    }
+
+    /** @test
+     * @throws \Exception
+     */
+    public function should_add_number_when_active()
+    {
+        $this->wordGenerator->setConfig('add_number', true);
+        $result = $this->wordGenerator->generatePassphrase();
+        $arr = explode($this->config['separator'], $result);
+        $this->assertIsNumeric($arr[0]);
+    }
+
+    /** @test
+     * @throws \Exception
+     */
+    public function should_not_add_number_when_inactive()
+    {
+        $this->wordGenerator->setConfig('add_number', false);
+        $result = $this->wordGenerator->generatePassphrase();
+        $arr = explode($this->config['separator'], $result);
+        $this->assertIsNotNumeric($arr[0]);
     }
 }


### PR DESCRIPTION
With this pull request, a config option is added that will prepend a number to your passphrases.
When `add_number` is enabled, a possible result looks like this:

```
93-neglector-silly-papaya-mankind-feel-portly
```