### PR TITLE
Randomize capitalization

### DIFF
--- a/README.md
+++ b/README.md
@@ -12,7 +12,7 @@ It uses [Diceware](http://world.std.com/~reinhold/diceware.html) wordlists and i
 
 ## Usage
 
-It's a breeze to generate a random diceware password, simply use the Facade like this:
+It's a breeze to generate a random diceware passphrase, simply use the Facade like this:
 
 ```php
 $passphrase = Diceware::generate();

--- a/README.md
+++ b/README.md
@@ -12,12 +12,12 @@ It uses [Diceware](http://world.std.com/~reinhold/diceware.html) wordlists and i
 
 ## Usage
 
-It is very easy to generate a random diceware password, simply use the Facade like this:
+It's a breeze to generate a random diceware password, simply use the Facade like this:
 
 ```php
 $passphrase = Diceware::generate();
 
-// returns 'unwind-cosmic-entryway-magnetic-stardust-ligament'
+// returns 'unwind-cosmic-entryway-MAGNETIC-stardust-ligament'
 return $passphrase;
 ```
 
@@ -43,13 +43,13 @@ php artisan vendor:publish --provider 'Martbock\Diceware\DicewareServiceProvider
 
 ## Configuration
 
-You may change the default settings in the [diceware.php config file](config/diceware.php) that will be published to
-your Laravel config directory once you install this package. Currently, the following options are supported:
+You may change the default settings in the [diceware.php config file](config/diceware.php) that you can publish to
+your Laravel config directory after you installed this package. Currently, the following options are supported:
 
 ```php
 'number_of_words'       => 6,
 'separator'             => '-',
-'capitalize'            => false,
+'capitalize'            => true,
 'add_number'            => false,
 'wordlist'              => 'english',
 'custom_wordlist_path'  => null,

--- a/config/diceware.php
+++ b/config/diceware.php
@@ -34,12 +34,13 @@ return [
     | Capitalize
     |--------------------------------------------------------------------------
     |
-    | If you want to capitalize each individual word in your passphrase,
+    | If you want to capitalize one random word in your passphrase,
     | set this option to `true`.
+    | Example: 'landscape-FAVORING-cover-mauve'
     |
     */
 
-    'capitalize' => false,
+    'capitalize' => true,
 
     /*
     |--------------------------------------------------------------------------

--- a/src/WordGenerator.php
+++ b/src/WordGenerator.php
@@ -144,11 +144,12 @@ class WordGenerator
     {
         $words = [];
         for ($i = 0; $i < $numberOfWords; $i++) {
-            $word = $this->getWord($this->generateDicedNumber());
-            if ($this->config['capitalize']) {
-                $word = ucfirst($word);
-            }
-            array_push($words, $word);
+            $words[] = strtolower($this->getWord($this->generateDicedNumber()));
+        }
+
+        if ($this->config['capitalize']) {
+            $i = array_rand($words);
+            $words[$i] = strtoupper($words[$i]);
         }
 
         return $words;

--- a/tests/Unit/WordGeneratorTest.php
+++ b/tests/Unit/WordGeneratorTest.php
@@ -6,7 +6,6 @@ use Martbock\Diceware\Exceptions\InvalidConfigurationException;
 use Martbock\Diceware\Exceptions\WordlistInvalidException;
 use Martbock\Diceware\Tests\TestCase;
 use Martbock\Diceware\WordGenerator;
-use function ucfirst;
 
 class WordGeneratorTest extends TestCase
 {
@@ -65,17 +64,25 @@ class WordGeneratorTest extends TestCase
     public function should_capitalize_when_active()
     {
         $this->wordGenerator->setConfig('capitalize', true);
-        $words = $this->wordGenerator->generateWords(1);
+        $words = $this->wordGenerator->generateWords(3);
+        $uppercaseCounter = 0;
+        $lowercaseCounter = 0;
         foreach ($words as $word) {
-            $this->assertEquals(ucfirst($word), $word);
+            if (strtoupper($word) === $word) {
+                $uppercaseCounter += 1;
+            } else {
+                $lowercaseCounter += 1;
+            }
         }
+        $this->assertEquals(1, $uppercaseCounter);
+        $this->assertEquals(2, $lowercaseCounter);
     }
 
     /** @test */
     public function should_not_capitalize_when_inactive()
     {
         $this->wordGenerator->setConfig('capitalize', false);
-        $words = $this->wordGenerator->generateWords(1);
+        $words = $this->wordGenerator->generateWords(2);
         foreach ($words as $word) {
             $this->assertEquals(strtolower($word), $word);
         }


### PR DESCRIPTION
Although the length of a passphrase has a significantly larger impact than its complexity, you may still want to increase the complexity by utilizing a larger character pool – for example by capitalizing words in your passphrase.

Until now, this package supported a `capitalize` option that would capitalize the first character of every word in the passphrase when enabled. However, an attacker may assume that a passphrase uses this steady pattern. Thus, the entropy improvement is gone.

The new randomized word capitalization is inspired by password managers like 1Password that have shifted from generating passphrases with capitalized characters in every word to uppercasing one randomly selected word in the passphrase.

The change in newly generated passphrases looks like this:

```diff
- Grueling-Argue-Implement-Scoundrel-Pretender-Lettuce
+ grueling-argue-IMPLEMENT-scoundrel-pretender-lettuce 
```

Additionally, capitalization is enabled by default now.