### PR TITLE
Resolve deprecation warning due to implicitly nulled parameters in PHP 8.4

### DIFF
--- a/src/DicewareClient.php
+++ b/src/DicewareClient.php
@@ -25,7 +25,7 @@ class DicewareClient
      *
      * @return string
      */
-    public function generate(int $numberOfWords = null, string $separator = null): string
+    public function generate(?int $numberOfWords = null, ?string $separator = null): string
     {
         return $this->wordGenerator->generatePassphrase($numberOfWords, $separator);
     }


### PR DESCRIPTION
When calling the `generate` function on PHP 8.4 (Laravel 12) a warning is issued due to the deprecation of implicitly nullable parameters. 

See: https://php.watch/versions/8.4/implicitly-marking-parameter-type-nullable-deprecated

Marking the params explicitly as nullable fixes the warning.